### PR TITLE
support node 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-import-resolver-node": "^0.3.4",
-    "eslint-import-resolver-webpack": "^0.13.0",
+    "eslint-import-resolver-webpack": "^0.13.2",
     "eslint-plugin-import": "^2.22.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Update dependencies to support node 17.
See change log: https://github.com/import-js/eslint-plugin-import/commit/c3633c6dc1906b2d7c0f208dc56897f63233875a#diff-ff016cb5178d4a25eca1b7a921acc19ef645438a780c424099049d5830ed586c