### PR TITLE
feat: add eslint-import-resolver-vite-ts to support vite

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,12 @@ try {
 } catch (e) {
   // ignore
 }
-
+try{
+  require.resolve('vite');
+  importResolver[require.resolve('eslint-import-resolver-vite-ts')]={
+  };
+} catch(e){
+}
 module.exports = {
   extends: [
     'airbnb-base',

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-import-resolver-node": "^0.3.6",
+    "eslint-import-resolver-vite-ts": "^1.1.1",
     "eslint-import-resolver-webpack": "^0.13.2",
     "eslint-plugin-import": "^2.25.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1737,6 +1737,11 @@ eslint-import-resolver-node@^0.3.6:
     debug "^3.2.7"
     resolve "^1.20.0"
 
+eslint-import-resolver-vite-ts@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-vite-ts/-/eslint-import-resolver-vite-ts-1.1.1.tgz#54c82d2460ae65bbbac28ec0104c25f0eb04e5bb"
+  integrity sha512-zYnjGx6rLNjCRJ++Dcbc4tVbtlRhskXzCOC/pK75BDk7iq4u4ckYGE8dwBCq9tPz6xPGio7PIQ2CTuaE/dGVlg==
+
 eslint-import-resolver-webpack@^0.13.2:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.2.tgz#fc813df0d08b9265cc7072d22393bda5198bdc1e"


### PR DESCRIPTION
Add eslint-import-resolver-vite-ts to support the vite of eslint-plugin-import for create-vue to use