### PR TITLE
✏️ Fix missing comma in configuration example

### DIFF
--- a/packages/eslint-config-airbnb/README.md
+++ b/packages/eslint-config-airbnb/README.md
@@ -56,7 +56,7 @@ module.exports = {
   ],
   rules: {
     'import/no-unresolved': 'error'
-  }
+  },
   settings: {
     ...createAliasSetting({
       '@': `${path.resolve(__dirname, './src')}`


### PR DESCRIPTION
This PR add a missing comma in documentation [here](https://github.com/vuejs/eslint-config-airbnb/blob/main/packages/eslint-config-airbnb/README.md?plain=1#L59) between two object properties.

It may be a minor issue, but regarding the popularity of this package, I think it is important to ensure to have a clean documentation, as a junior developper could not spot this missing comma and fight to debug the error.