### PR TITLE
fix: remove no-setup-props-destructure

### DIFF
--- a/packages/eslint-config-airbnb/rules/misc.js
+++ b/packages/eslint-config-airbnb/rules/misc.js
@@ -14,10 +14,5 @@ module.exports = {
     // Corresponding to `react/no-typos` but a little bit different.
     // https://github.com/airbnb/javascript/blob/cbf9ade10a2f6f06c9da6dbfa25b344bee4bbef6/packages/eslint-config-airbnb/rules/react.js#L426-L428
     'vue/no-potential-component-option-typo': 'error',
-
-    // https://eslint.vuejs.org/rules/no-setup-props-destructure.html
-    // (The rule is already in `plugin:vue/essential` and `plugin:vue/vue3-essential` ruleset.)
-    // Corresponding to `react/destructuring-assignment` but the requirement in Vue is the contrary:
-    'vue/no-setup-props-destructure': 'error',
   },
 };


### PR DESCRIPTION
This rule is now deprecated and no longer belongs to the `plugin:vue/vue3-essential` ruleset.
In fact, it's now an alias of `vue/no-setup-props-reactivity-loss` that radically disallows all intention to initiate a ref with a prop. `vue/no-setup-props-reactivity-loss` isn't categorized as essential/strongly-recommended/recommended.
I think we should just remove this.